### PR TITLE
feat: implement manual question generation with mode switching (Issue #18)

### DIFF
--- a/backend/src/modules/livequizzes/controllers/PollRoomController.ts
+++ b/backend/src/modules/livequizzes/controllers/PollRoomController.ts
@@ -86,20 +86,64 @@ export class PollRoomController {
   @Post('/:code/polls')
   async createPollInRoom(
     @Param('code') roomCode: string,
-    @Body() body: { question: string; options: string[]; correctOptionIndex: number; creatorId: string; timer?: number }
+    @Body() body: { question: string; options: string[]; correctOptionIndex: number; creatorId: string; timer?: number; source?: 'manual' | 'auto' }
   ) {
     const room = await this.roomService.getRoomByCode(roomCode);
     if (!room) throw new Error('Invalid room');
+
+    // Verify that only the teacher can create manual questions
+    if (body.source === 'manual' && body.creatorId !== room.teacherId) {
+      throw new BadRequestError('Only the teacher can create manual questions');
+    }
+
     return await this.pollService.createPoll(
       roomCode,
       {
         question: body.question,
         options: body.options,
         correctOptionIndex: body.correctOptionIndex,
-        timer: body.timer
+        timer: body.timer,
+        source: body.source ?? 'manual',
+        createdBy: body.creatorId
       }
     );
+  }
 
+  // 🔹 Switch Question Generation Mode
+  @Post('/:code/question-mode')
+  async setQuestionMode(
+    @Param('code') roomCode: string,
+    @Body() body: { mode: 'manual' | 'auto' | 'paused'; teacherId: string }
+  ) {
+    const updatedRoom = await this.roomService.setQuestionMode(roomCode, body.mode, body.teacherId);
+    
+    // Emit mode change to all clients in the room
+    pollSocket.emitToRoom(roomCode, 'question-mode-changed', {
+      roomCode,
+      mode: body.mode,
+      timestamp: new Date()
+    });
+
+    return {
+      success: true,
+      roomCode,
+      questionMode: body.mode,
+      message: `Question mode set to ${body.mode}`
+    };
+  }
+
+  // 🔹 Get Current Question Mode
+  @Get('/:code/question-mode')
+  async getQuestionMode(@Param('code') roomCode: string) {
+    const mode = await this.roomService.getQuestionMode(roomCode);
+    if (!mode) {
+      throw new NotFoundError('Room not found');
+    }
+    return {
+      success: true,
+      roomCode,
+      questionMode: mode
+    };
   }
 
   //@Authorized(['teacher'])

--- a/backend/src/modules/livequizzes/interfaces/PollRoom.ts
+++ b/backend/src/modules/livequizzes/interfaces/PollRoom.ts
@@ -11,6 +11,8 @@ export interface Poll {
   correctOptionIndex: number;
   timer: number;
   createdAt: Date;
+  source?: 'manual' | 'auto'; // Question source
+  createdBy?: string; // User ID who created the question
   answers: PollAnswer[];
 }
 
@@ -21,5 +23,6 @@ export interface Room {
   teacherName?: string;
   createdAt: Date;
   status: 'active' | 'ended';
+  questionMode?: 'manual' | 'auto' | 'paused'; // Question generation mode
   polls: Poll[];
 }

--- a/backend/src/modules/livequizzes/services/PollService.ts
+++ b/backend/src/modules/livequizzes/services/PollService.ts
@@ -28,6 +28,8 @@ export class PollService {
     options: string[];
     correctOptionIndex: number;
     timer?: number;
+    source?: 'manual' | 'auto';
+    createdBy?: string;
   }) {
     const pollId = crypto.randomUUID();
 
@@ -38,6 +40,8 @@ export class PollService {
       correctOptionIndex: data.correctOptionIndex,
       timer: data.timer ?? 30,
       createdAt: new Date(),
+      source: data.source ?? 'manual',
+      createdBy: data.createdBy,
       answers: []
     };
 

--- a/backend/src/modules/livequizzes/services/RoomService.ts
+++ b/backend/src/modules/livequizzes/services/RoomService.ts
@@ -215,4 +215,36 @@ export class RoomService {
     const updatedRoom = await Room.findOneAndUpdate({roomCode},{$pull:{students:userObjectId}},{new:true})
     return updatedRoom
   }
+
+  /**
+   * Switch question generation mode for a room
+   * Only the teacher/host can switch modes
+   */
+  async setQuestionMode(roomCode: string, mode: 'manual' | 'auto' | 'paused', teacherId: string): Promise<RoomType | null> {
+    const room = await Room.findOne({ roomCode }).lean();
+    if (!room) {
+      throw new NotFoundError('Room not found');
+    }
+
+    // Verify that the user is the teacher
+    if (room.teacherId !== teacherId) {
+      throw new Error('Only the room host can change question mode');
+    }
+
+    const updatedRoom = await Room.findOneAndUpdate(
+      { roomCode },
+      { questionMode: mode },
+      { new: true }
+    ).lean();
+
+    return updatedRoom;
+  }
+
+  /**
+   * Get current question mode for a room
+   */
+  async getQuestionMode(roomCode: string): Promise<string | null> {
+    const room = await Room.findOne({ roomCode }).lean();
+    return room ? (room.questionMode || 'manual') : null;
+  }
 }

--- a/backend/src/shared/database/models/Room.ts
+++ b/backend/src/shared/database/models/Room.ts
@@ -13,6 +13,8 @@ const PollSchema = new mongoose.Schema({
   correctOptionIndex: { type: Number, default: -1 },
   timer: { type: Number, default: 30 },
   createdAt: { type: Date, default: Date.now },
+  source: { type: String, enum: ['manual', 'auto'], default: 'manual' }, // Question source
+  createdBy: { type: String }, // User ID who created the question
   answers: [AnswerSchema]
 });
 
@@ -24,6 +26,7 @@ const RoomSchema = new mongoose.Schema({
   createdAt: { type: Date, default: Date.now },
   endedAt: { type: Date }, 
   status: { type: String, enum: ['active', 'ended'], default: 'active' },
+  questionMode: { type: String, enum: ['manual', 'auto', 'paused'], default: 'manual' }, // Question generation mode
   polls: [PollSchema],
   students: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }]
 });


### PR DESCRIPTION
## Description
Implements manual question generation system with mode switching as per Issue #18.

## Changes
- ✅ Added `questionMode` field to Room schema (manual/auto/paused)
- ✅ Added `source` and `createdBy` tracking for questions
- ✅ Implemented mode switching endpoints: `POST /rooms/:code/question-mode`
- ✅ Added teacher-only access control for manual question creation
- ✅ Real-time mode change notifications via Socket.IO
- ✅ Manual and auto-generated questions can coexist

## Features
- Host can switch between manual/auto/paused modes at any time
- Only teacher/host can create manual questions
- Mode changes emit real-time events to all clients
- Questions are tagged with their source (manual/auto)
- Backward compatible with existing polls

## API Endpoints

### Switch Question Mode
**POST** `/livequizzes/rooms/:code/question-mode`
```json
{
  "mode": "manual",
  "teacherId": "teacher-id"
}