### PR TITLE
fix: joined students not visible in teacher poll room

### DIFF
--- a/backend/src/modules/livequizzes/interfaces/PollRoom.ts
+++ b/backend/src/modules/livequizzes/interfaces/PollRoom.ts
@@ -35,13 +35,7 @@ export interface Room {
     pollRestricted: boolean;
   };
   joinedStudents?: string[];
-  coHosts?: {
-    userId: string;
-    isActive: boolean;
-    addedBy: string;
-    isMicMuted: boolean;
-    addedAt: Date;
-  }[];
+  students?: {firstName: string, email: string}[]
 }
 
 export interface CohostJwtPayload extends JwtPayload {
@@ -56,9 +50,12 @@ export interface GetCohostRoom {
 
 export interface ActiveCohost {
   userId: string;
+  isActive: boolean;
   firstName: string;
   lastName: string;
   email: string;
   addedAt: Date;
+  addedBy: string;
+  isMicMuted: boolean;
 }
 

--- a/backend/src/modules/livequizzes/services/RoomService.ts
+++ b/backend/src/modules/livequizzes/services/RoomService.ts
@@ -225,6 +225,7 @@ export class RoomService {
       createdAt: roomDoc.createdAt,
       endedAt: roomDoc.endedAt,
       status: roomDoc.status,
+      students: roomDoc.students,
       // Safely handle populated objects (s._id) or raw strings
       totalStudents: new Set(roomDoc.students?.map((s: any) => s._id ? s._id.toString() : s.toString()) || []).size,
       coHosts: roomDoc.coHosts,


### PR DESCRIPTION
**Description**

This PR fixes an issue where students were not being displayed in the teacher's poll room after joining.