### PR TITLE
Poll difficulty feedback (Easy/Medium/Hard) + teacher insights

### DIFF
--- a/backend/src/modules/livequizzes/controllers/PollRoomController.ts
+++ b/backend/src/modules/livequizzes/controllers/PollRoomController.ts
@@ -34,6 +34,7 @@ import mime from 'mime-types';
 import * as fsp from 'fs/promises';
 import { CreateInMemoryPollDto, InMemoryPollResponse, InMemoryPollResult, SubmitInMemoryAnswerDto } from '../validators/LivepollValidator.js';
 import { validate } from 'class-validator';
+import { SubmitPollDifficultyDto } from '../validators/PollDifficultyValidator.js';
 
 dotenv.config();
 const appOrigins = process.env.APP_ORIGINS;
@@ -155,11 +156,34 @@ export class PollRoomController {
     return { success: true };
   }
 
+  @Post('/:code/polls/:pollId/difficulty')
+  @HttpCode(200)
+  async submitPollDifficulty(
+    @Param('code') roomCode: string,
+    @Param('pollId') pollId: string,
+    @Body() body: SubmitPollDifficultyDto
+  ) {
+    const dto = Object.assign(new SubmitPollDifficultyDto(), body);
+    const errors = await validate(dto);
+    if (errors.length > 0) {
+      throw new BadRequestError('Invalid difficulty payload');
+    }
+
+    await this.pollService.submitDifficulty(roomCode, pollId, dto.userId, dto.difficulty);
+    return { success: true };
+  }
+
   // Fetch Results for All Polls in Room
   //@Authorized()
   @Get('/:code/polls/results')
   async getResultsForRoom(@Param('code') code: string) {
     return await this.pollService.getPollResults(code);
+  }
+
+  @Get('/:code/polls/insights')
+  @HttpCode(200)
+  async getPollInsights(@Param('code') roomCode: string) {
+    return await this.pollService.getPollInsights(roomCode);
   }
 
   //@Authorized(['teacher'])

--- a/backend/src/modules/livequizzes/interfaces/PollRoom.ts
+++ b/backend/src/modules/livequizzes/interfaces/PollRoom.ts
@@ -5,6 +5,8 @@ export interface PollAnswer {
   answerIndex: number;
   answeredAt: Date;
   points?: number;
+  difficulty?: 'easy' | 'medium' | 'hard' | null;
+  difficultyAnsweredAt?: Date | null;
 }
 
 export interface Poll {
@@ -58,4 +60,3 @@ export interface ActiveCohost {
   addedBy: string;
   isMicMuted: boolean;
 }
-

--- a/backend/src/modules/livequizzes/services/PollService.ts
+++ b/backend/src/modules/livequizzes/services/PollService.ts
@@ -8,6 +8,9 @@ import UserAchievement from '#root/shared/database/models/UserAchievement.js';
 import Badge from '#root/shared/database/models/Badge.js';
 import { updateRoomStats } from '../utils/statsService.js';
 import { calculateScore } from '../utils/calculateScore.js';
+import { BadRequestError, NotFoundError } from 'routing-controllers';
+
+type PollDifficulty = 'easy' | 'medium' | 'hard';
 
 interface InMemoryPoll {
   pollId: string;
@@ -148,6 +151,142 @@ export class PollService {
         badges: newlyUnlockedBadges,
       });
     }
+  }
+
+  async submitDifficulty(
+    roomCode: string,
+    pollId: string,
+    userId: string,
+    difficulty: PollDifficulty,
+  ) {
+    const room = await Room.findOne({ roomCode });
+    if (!room) throw new NotFoundError('Room not found');
+
+    const poll = room.polls.find(p => p._id === pollId);
+    if (!poll) throw new NotFoundError('Poll not found');
+
+    const answers = poll.answers?.filter(a => a.userId === userId) ?? [];
+    if (answers.length === 0) {
+      throw new NotFoundError('Answer not found for this user');
+    }
+
+    // Set difficulty on the latest answer (by answeredAt)
+    const latestAnswer = answers.reduce((latest, current) => {
+      const latestTime = latest?.answeredAt?.getTime?.() ?? 0;
+      const currentTime = current?.answeredAt?.getTime?.() ?? 0;
+      return currentTime >= latestTime ? current : latest;
+    }, answers[0]);
+
+    if (!latestAnswer) {
+      throw new NotFoundError('Answer not found for this user');
+    }
+
+    if (latestAnswer.difficulty) {
+      throw new BadRequestError('Difficulty already submitted');
+    }
+
+    latestAnswer.difficulty = difficulty;
+    latestAnswer.difficultyAnsweredAt = new Date();
+    await room.save();
+  }
+
+  async getPollInsights(roomCode: string) {
+    const room = await Room.findOne({ roomCode }).lean();
+    if (!room) throw new NotFoundError('Room not found');
+
+    const thresholdHighCorrect = 60; // percent
+
+    const insights = (room.polls ?? []).map(poll => {
+      // Dedupe by userId (take latest answeredAt)
+      const latestByUser = new Map<string, any>();
+      for (const ans of poll.answers ?? []) {
+        const previous = latestByUser.get(ans.userId);
+        const prevTime = previous?.answeredAt ? new Date(previous.answeredAt).getTime() : 0;
+        const curTime = ans?.answeredAt ? new Date(ans.answeredAt).getTime() : 0;
+        if (!previous || curTime >= prevTime) {
+          latestByUser.set(ans.userId, ans);
+        }
+      }
+      const answers = Array.from(latestByUser.values());
+      const total = answers.length;
+      const correctCount = answers.filter(a => a.answerIndex === poll.correctOptionIndex).length;
+      const correctPercent = total > 0 ? Math.round((correctCount / total) * 100) : 0;
+
+      const difficultyCounts = { easy: 0, medium: 0, hard: 0 };
+      for (const a of answers) {
+        if (a?.difficulty === 'easy') difficultyCounts.easy += 1;
+        if (a?.difficulty === 'medium') difficultyCounts.medium += 1;
+        if (a?.difficulty === 'hard') difficultyCounts.hard += 1;
+      }
+      const difficultyTotal = difficultyCounts.easy + difficultyCounts.medium + difficultyCounts.hard;
+      const difficultyPercent = {
+        easy: difficultyTotal ? Math.round((difficultyCounts.easy / difficultyTotal) * 100) : 0,
+        medium: difficultyTotal ? Math.round((difficultyCounts.medium / difficultyTotal) * 100) : 0,
+        hard: difficultyTotal ? Math.round((difficultyCounts.hard / difficultyTotal) * 100) : 0,
+      };
+
+      const isHighCorrect = correctPercent >= thresholdHighCorrect;
+      let dominantDifficulty: 'easy' | 'medium' | 'hard' | 'mixed' | 'unknown' = 'unknown';
+      if (difficultyTotal === 0) {
+        dominantDifficulty = 'unknown';
+      } else {
+        const max = Math.max(difficultyCounts.easy, difficultyCounts.medium, difficultyCounts.hard);
+        const winners = (['easy', 'medium', 'hard'] as const).filter(
+          d => difficultyCounts[d] === max,
+        );
+        dominantDifficulty = winners.length === 1 ? winners[0] : 'mixed';
+      }
+
+      const majorityLabel =
+        dominantDifficulty === 'easy'
+          ? 'Easy'
+          : dominantDifficulty === 'medium'
+          ? 'Medium'
+          : dominantDifficulty === 'hard'
+          ? 'Hard'
+          : dominantDifficulty === 'mixed'
+          ? 'Mixed'
+          : 'Unknown';
+
+      const insight = (() => {
+        if (total === 0) return 'No responses yet.';
+
+        if (dominantDifficulty === 'medium') {
+          return `${correctPercent}% correct, majority marked Medium → Balanced difficulty, good concept-check question`;
+        }
+
+        if (dominantDifficulty === 'easy' && isHighCorrect) {
+          return 'Well-understood concept, suitable for quick checks';
+        }
+        if (dominantDifficulty === 'hard' && isHighCorrect) {
+          return 'Concept understood but perceived tricky—good for exams';
+        }
+        if (dominantDifficulty === 'easy' && !isHighCorrect) {
+          return 'Likely ambiguity or misconception—review question';
+        }
+        if (dominantDifficulty === 'hard' && !isHighCorrect) {
+          return 'Concept not understood—needs reteaching';
+        }
+
+        // fallback
+        return `${correctPercent}% correct, majority marked ${majorityLabel} → Review results`;
+      })();
+
+      return {
+        pollId: poll._id,
+        question: poll.question,
+        totalAnswers: total,
+        correctCount,
+        correctPercent,
+        difficultyCounts,
+        difficultyPercent,
+        difficultyTotal,
+        dominantDifficulty,
+        insight,
+      };
+    });
+
+    return { roomCode, insights };
   }
 
   async getPollResults(roomCode: string) {

--- a/backend/src/modules/livequizzes/validators/PollDifficultyValidator.ts
+++ b/backend/src/modules/livequizzes/validators/PollDifficultyValidator.ts
@@ -1,0 +1,13 @@
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+
+export class SubmitPollDifficultyDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsIn(['easy', 'medium', 'hard'])
+  difficulty: 'easy' | 'medium' | 'hard';
+}
+

--- a/backend/src/shared/database/models/Room.ts
+++ b/backend/src/shared/database/models/Room.ts
@@ -4,7 +4,9 @@ const AnswerSchema = new mongoose.Schema({
   userId: { type: String, required: true },
   answerIndex: { type: Number, required: true },
   answeredAt: { type: Date, default: Date.now },
-  points: { type: Number, default: 0 }
+  points: { type: Number, default: 0 },
+  difficulty: { type: String, enum: ['easy', 'medium', 'hard'], default: null },
+  difficultyAnsweredAt: { type: Date, default: null },
 });
 
 const PollSchema = new mongoose.Schema({

--- a/frontend/src/pages/student/StudentPollRoom.tsx
+++ b/frontend/src/pages/student/StudentPollRoom.tsx
@@ -11,6 +11,7 @@ import socket from "@/lib/api/socket";
 import { useAuthStore } from "@/lib/store/auth-store";
 import type { UserAchievement } from "@/shared/types";
 import { getBadgeTier } from "@/shared/getBadgeTier";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
 //const Socket_URL = import.meta.env.VITE_SOCKET_URL;
 //const socket = io(Socket_URL);
@@ -72,6 +73,10 @@ export default function StudentPollRoom() {
   const [newBadgePopup, setNewBadgePopup] = useState<UserAchievement | null>(null);
   const [badgePopupQueue, setBadgePopupQueue] = useState<UserAchievement[]>([]);
   const [showConfetti, setShowConfetti] = useState(false);
+  const [difficultyDialogOpen, setDifficultyDialogOpen] = useState(false);
+  const [difficultyPollId, setDifficultyPollId] = useState<string | null>(null);
+  const [difficultyPollQuestion, setDifficultyPollQuestion] = useState<string>("");
+  const [submittingDifficulty, setSubmittingDifficulty] = useState(false);
   const email = useAuthStore((state) => state.user?.email)
   useEffect(() => {
   socket.on("room-data", (room) => {
@@ -242,10 +247,43 @@ export default function StudentPollRoom() {
         setAnsweredPolls(prev => ({ ...prev, [pollId]: answerIndex }));
         setIsAnimating(false);
         toast.success("Vote submitted!");
+
+        // Prompt difficulty feedback (once per poll)
+        const feedbackKey = `pollDifficulty_${roomCode}_${pollId}`;
+        const alreadyGiven = localStorage.getItem(feedbackKey);
+        if (!alreadyGiven) {
+          const poll =
+            livePolls.find(p => p._id === pollId) ||
+            allRoomPolls.find(p => p._id === pollId);
+          setDifficultyPollId(pollId);
+          setDifficultyPollQuestion(poll?.question ?? "This question");
+          setDifficultyDialogOpen(true);
+        }
       }, 300);
     } catch {
       setIsAnimating(false);
       toast.error("Failed to submit vote");
+    }
+  };
+
+  const submitDifficulty = async (difficulty: 'easy' | 'medium' | 'hard') => {
+    if (!difficultyPollId || !roomCode || !user?.uid) return;
+    try {
+      setSubmittingDifficulty(true);
+      await api.post(`/livequizzes/rooms/${roomCode}/polls/${difficultyPollId}/difficulty`, {
+        userId: user.uid,
+        difficulty,
+      });
+      localStorage.setItem(`pollDifficulty_${roomCode}_${difficultyPollId}`, difficulty);
+      toast.success("Thanks for the feedback!");
+      setDifficultyDialogOpen(false);
+      setDifficultyPollId(null);
+      setDifficultyPollQuestion("");
+    } catch (e) {
+      console.error("Failed to submit difficulty:", e);
+      toast.error("Could not save difficulty feedback. Please try again.");
+    } finally {
+      setSubmittingDifficulty(false);
     }
   };
   const cleanupRoom = () => {
@@ -330,6 +368,43 @@ export default function StudentPollRoom() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-violet-50 via-purple-50 to-pink-50 dark:from-gray-900 dark:via-violet-900/20 dark:to-purple-900/20">
+      <Dialog open={difficultyDialogOpen} onOpenChange={(open) => !submittingDifficulty && setDifficultyDialogOpen(open)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Quick feedback</DialogTitle>
+            <DialogDescription>
+              How difficult was this question?
+              <span className="block mt-1 text-foreground/80 line-clamp-2">
+                {difficultyPollQuestion}
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+            <Button
+              variant="outline"
+              disabled={submittingDifficulty}
+              onClick={() => submitDifficulty('easy')}
+            >
+              Easy
+            </Button>
+            <Button
+              variant="outline"
+              disabled={submittingDifficulty}
+              onClick={() => submitDifficulty('medium')}
+            >
+              Medium
+            </Button>
+            <Button
+              variant="outline"
+              disabled={submittingDifficulty}
+              onClick={() => submitDifficulty('hard')}
+            >
+              Hard
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
       {showConfetti && (
         <div className="fixed inset-0 pointer-events-none z-40">
           <Confetti recycle={false} numberOfPieces={260} />

--- a/frontend/src/pages/teacher/TeacherPollRoom.tsx
+++ b/frontend/src/pages/teacher/TeacherPollRoom.tsx
@@ -375,6 +375,18 @@ export default function TeacherPollRoom() {
   const [timer, _setTimer] = useState<number>(30);
   const [maxPoints, setMaxPoints] = useState<number | ''>(20);
   const [pollResults, setPollResults] = useState<PollResults>({});
+  type PollDifficultyCounts = { easy: number; medium: number; hard: number };
+  type PollInsight = {
+    pollId: string;
+    question: string;
+    totalAnswers: number;
+    correctPercent: number;
+    difficultyCounts: PollDifficultyCounts;
+    dominantDifficulty: string;
+    insight: string;
+  };
+  const [pollInsightsByQuestion, setPollInsightsByQuestion] = useState<Record<string, PollInsight>>({});
+  const [loadingInsights, setLoadingInsights] = useState(false);
   // State for live poll results
   type LivePollResult = {
     responses: Record<string, number>; // optionIndex: count
@@ -1394,6 +1406,24 @@ export default function TeacherPollRoom() {
     }
   };
 
+  const fetchPollInsights = async () => {
+    try {
+      setLoadingInsights(true);
+      const res = await api.get(`/livequizzes/rooms/${roomCode}/polls/insights`);
+      const insights: PollInsight[] = res.data?.insights || [];
+      const mapped: Record<string, PollInsight> = {};
+      for (const item of insights) {
+        if (item?.question) mapped[item.question] = item;
+      }
+      setPollInsightsByQuestion(mapped);
+    } catch (e) {
+      console.error('Failed to fetch poll insights:', e);
+      // Don’t toast on every open; keep it quiet unless needed
+    } finally {
+      setLoadingInsights(false);
+    }
+  };
+
 
   useEffect(() => {
     setIsTranscribing(!!transcriber.output?.isBusy);
@@ -1936,6 +1966,7 @@ export default function TeacherPollRoom() {
     setShowResultsModal(true);
     setShowPreview(false)
     setShowPollModal(false);
+    fetchPollInsights();
   };
 
   const handleVoiceRecorderTab = () => {
@@ -4045,7 +4076,10 @@ export default function TeacherPollRoom() {
                           <div className="flex items-center gap-2">
                             {Object.keys(pollResults).length > 0 && (
                               <Button
-                                onClick={fetchResults}
+                                onClick={() => {
+                                  fetchResults();
+                                  fetchPollInsights();
+                                }}
                                 variant="outline"
                                 size="sm"
                                 className="border-purple-500 text-purple-600 hover:bg-purple-50 hover:text-purple-700 dark:border-purple-400 dark:text-purple-300 dark:hover:bg-purple-900/30 text-xs sm:text-sm"
@@ -4070,7 +4104,10 @@ export default function TeacherPollRoom() {
                               Poll results will appear here once students submit their responses.
                             </p>
                             <Button
-                              onClick={fetchResults}
+                              onClick={() => {
+                                fetchResults();
+                                fetchPollInsights();
+                              }}
                               variant="outline"
                               className="border-purple-500 text-purple-600 hover:bg-purple-50 hover:text-purple-700 dark:border-purple-400 dark:text-purple-300 dark:hover:bg-purple-900/30"
                             >
@@ -4117,6 +4154,27 @@ export default function TeacherPollRoom() {
                                               </Button>
                                             </div>
                                           </div>
+
+                                          {pollInsightsByQuestion[pollQuestion] && (
+                                            <div className="mt-2 space-y-1">
+                                              <div className="flex flex-wrap gap-2">
+                                                <span className="text-xs bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200 px-2 py-1 rounded">
+                                                  Correct: {pollInsightsByQuestion[pollQuestion].correctPercent}%
+                                                </span>
+                                                <span className="text-xs bg-slate-100 text-slate-700 dark:bg-slate-700/50 dark:text-slate-200 px-2 py-1 rounded">
+                                                  Difficulty — E:{pollInsightsByQuestion[pollQuestion].difficultyCounts.easy} M:{pollInsightsByQuestion[pollQuestion].difficultyCounts.medium} H:{pollInsightsByQuestion[pollQuestion].difficultyCounts.hard}
+                                                </span>
+                                                {loadingInsights && (
+                                                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                                                    Loading insights…
+                                                  </span>
+                                                )}
+                                              </div>
+                                              <p className="text-xs text-slate-600 dark:text-slate-300">
+                                                {pollInsightsByQuestion[pollQuestion].insight}
+                                              </p>
+                                            </div>
+                                          )}
                                         </CardHeader>
 
                                         <CardContent className="pt-0">


### PR DESCRIPTION
## Summary
Adds a “Poll Difficulty Feedback” flow to help teachers understand perceived question difficulty alongside correctness.
- After a student submits an answer, the UI prompts: **Easy / Medium / Hard**
- Feedback is stored per poll answer
- Teacher can view **correctness + difficulty distribution + an auto-generated one-line insight** in Poll Results

### UI Changes
- Student: shows a post-submit dialog “How difficult was this question?” (Easy/Medium/Hard)
- Teacher: Poll Results cards now show:
  - Correct %
  - Difficulty counts (E/M/H)
  - One-line insight

## Working
- Student submits a poll answer → difficulty dialog appears
- Student selects Easy/Medium/Hard
- Teacher opens Poll Results → sees correctness + E/M/H counts
- Insights update after student feedback
